### PR TITLE
feat: add tfd get command to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ The tool will attempt to automatically detect the content type:
 -   **Text** is printed to the console.
 -   Other binary or numerical data is displayed in a readable format.
 
+### Getting a specific feature
+
+To get a single feature from a record by its key:
+
+```bash
+tfd get /path/to/your/data.tfrecord:your_record_key:your_feature_name
+```
+
+The tool will attempt to automatically detect the content type, similar to the `extract` command.
+
 ### TensorFlow Interoperability
 
 Read `tfd_utils` files with TensorFlow:

--- a/src/tfd_utils/cli.py
+++ b/src/tfd_utils/cli.py
@@ -79,8 +79,8 @@ def get_feature(args):
     try:
         path, key, feature_name = args.spec.rsplit(':', 2)
     except ValueError:
-        print("Invalid format for 'get' command. Expected format: path:key:feature_name")
-        return
+        print("Invalid format for 'get' command. Expected format: path:key:feature_name", file=sys.stderr)
+        sys.exit(1)
 
     reader = TFRecordRandomAccess(path)
     feature_value = reader.get_feature(key, feature_name)

--- a/src/tfd_utils/cli.py
+++ b/src/tfd_utils/cli.py
@@ -86,8 +86,8 @@ def get_feature(args):
     feature_value = reader.get_feature(key, feature_name)
 
     if feature_value is None:
-        print(f"Feature '{feature_name}' not found for key '{key}'.")
-        return
+        print(f"Feature '{feature_name}' not found for key '{key}'.", file=sys.stderr)
+        sys.exit(1)
 
     if isinstance(feature_value, bytes):
         # Try to detect image format from magic numbers

--- a/src/tfd_utils/cli.py
+++ b/src/tfd_utils/cli.py
@@ -74,6 +74,49 @@ def extract_record(args):
         elif feature.float_list.value:
             print(f"Feature '{feature_name}' (float): {list(feature.float_list.value)}")
 
+def get_feature(args):
+    """Extract and display a single feature from a record."""
+    try:
+        path, key, feature_name = args.spec.rsplit(':', 2)
+    except ValueError:
+        print("Invalid format for 'get' command. Expected format: path:key:feature_name")
+        return
+
+    reader = TFRecordRandomAccess(path)
+    feature_value = reader.get_feature(key, feature_name)
+
+    if feature_value is None:
+        print(f"Feature '{feature_name}' not found for key '{key}'.")
+        return
+
+    if isinstance(feature_value, bytes):
+        # Try to detect image format from magic numbers
+        image_format = None
+        if feature_value.startswith(b'\xff\xd8'):
+            image_format = 'jpeg'
+        elif feature_value.startswith(b'\x89PNG\r\n\x1a\n'):
+            image_format = 'png'
+        elif feature_value.startswith(b'GIF87a') or feature_value.startswith(b'GIF89a'):
+            image_format = 'gif'
+
+        if image_format:
+            output_filename = f"{key}_{feature_name}_0.{image_format}"
+            with open(output_filename, 'wb') as f:
+                f.write(feature_value)
+            print(f"Saved image content from feature '{feature_name}' to {output_filename}")
+        else:
+            # Not an image, try to decode as text
+            try:
+                text = feature_value.decode('utf-8')
+                print(f"Feature '{feature_name}[0]' (text): {text}")
+            except UnicodeDecodeError:
+                print(f"Feature '{feature_name}[0]' (binary): {len(feature_value)} bytes")
+
+    elif isinstance(feature_value, int):
+        print(f"Feature '{feature_name}' (int64): [{feature_value}]")
+    elif isinstance(feature_value, float):
+        print(f"Feature '{feature_name}' (float): [{feature_value}]")
+
 def main():
     """Main entry point for the tfd-utils CLI."""
     parser = argparse.ArgumentParser(description="TFRecord Utilities CLI")
@@ -89,6 +132,11 @@ def main():
     parser_extract.add_argument('path', help="Path to the TFRecord file or directory of files")
     parser_extract.add_argument('key', help="Key of the record to extract")
     parser_extract.set_defaults(func=extract_record)
+
+    # 'get' command
+    parser_get = subparsers.add_parser('get', help="Extract a single feature from a record by key")
+    parser_get.add_argument('spec', help="Specification in the format 'path:key:feature_name'")
+    parser_get.set_defaults(func=get_feature)
 
     args = parser.parse_args()
     args.func(args)

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -51,4 +51,23 @@ def test_cli_extract_record(test_data):
     assert os.path.exists(image_file)
     os.remove(image_file)
 
+def test_cli_get_feature(test_data):
+    tfrecord_file = os.path.join(test_data, "test_data_000.tfrecord")
+    key = "test_000_0002"
+    feature_name = "width"
+    spec = f"{tfrecord_file}:{key}:{feature_name}"
+    result = subprocess.run(["uv", "run", "tfd", "get", spec], capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert f"Feature '{feature_name}' (int64): [240]" in result.stdout
+
+def test_cli_get_feature_bytes(test_data):
+    tfrecord_file = os.path.join(test_data, "test_data_000.tfrecord")
+    key = "test_000_0003"
+    feature_name = "format"
+    spec = f"{tfrecord_file}:{key}:{feature_name}"
+    result = subprocess.run(["uv", "run", "tfd", "get", spec], capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert f"Feature '{feature_name}[0]' (text): JPEG" in result.stdout
 


### PR DESCRIPTION
Adds a new `tfd get` command to the CLI that allows users to extract a single feature from a TFRecord by key.

The command uses the format `tfd get <path>:<key>:<feature_name>` to specify the file, record key, and feature to extract.

This commit includes:
- Implementation of the `get` command in `src/tfd_utils/cli.py`.
- Documentation for the new command in `README.md`.
- Integration tests for the `get` command in `tests/integration/test_cli.py`.